### PR TITLE
Update solidity-1.md

### DIFF
--- a/tutorials/solidity/solidity-1.md
+++ b/tutorials/solidity/solidity-1.md
@@ -637,7 +637,7 @@ contract DougEnabled {
     function setDougAddress(address dougAddr) returns (bool result){
         // Once the doug address is set, don't allow it to be set again, except by the
         // doug contract itself.
-        if(DOUG != 0x0 && dougAddr != DOUG){
+        if(DOUG != 0x0 && msg.sender != DOUG){
             return false;
         }
         DOUG = dougAddr;
@@ -691,7 +691,7 @@ contract DougEnabled {
     function setDougAddress(address dougAddr) returns (bool result){
         // Once the doug address is set, don't allow it to be set again, except by the
         // doug contract itself.
-        if(DOUG != 0x0 && dougAddr != DOUG){
+        if(DOUG != 0x0 && msg.sender != DOUG){
             return false;
         }
         DOUG = dougAddr;


### PR DESCRIPTION
The condition in SetDougAddress function in DougEnabled didn't make sense to me. Perhaps I have misunderstood but currently, assuming DOUG != 0x0, the new dougAddr must be equal to DOUG in order to proceed past the conditional statement? In which case, the statement following, DOUG = dougAddr would be redundant as they are the same anyway and consequently it is not possible for any contract, not even the current DOUG, to change the address of DOUG?

Checking for msg.sender != DOUG made sense to me?