### PR TITLE
Update contracts-interacting.md

### DIFF
--- a/tutorials/contracts-interacting.md
+++ b/tutorials/contracts-interacting.md
@@ -137,7 +137,7 @@ getValue(changeValue);
 
 The code should be self explanatory if you understand even a little bit of javascript. Once we properly instantiate all of the objects then there are three functions.
 
-The first function, the `getValue` function will call the `get` function of `idi.sol` (see the previous tutorial for the code of that contract) and then it will display the result of that to the command line. There is some funkiness with the returns that we get from the contracts right now (another thing we're working to smooth out), so for now we have to display `result['c'][0]` rather than just `result`. This function takes a callback which fires after the result of the call to idi.sol's get function (which simply returns the `storedData`).
+The first function, the `getValue` function will call the `get` function of `idi.sol` (see the previous tutorial for the code of that contract) and then it will display the result of that to the command line. This function takes a callback which fires after the result of the call to idi.sol's get function (which simply returns the `storedData`).
 
 The second function is a simple function which will prompt the user to change the value (there is no validation here to make sure it is a number, so when playing with this just sure make it is a number). Once the user has entered what the value should be then the `setValue` function will be called.
 


### PR DESCRIPTION
You are not using this `result['c'][0]`  anymore in this tutorial. You do use it in the idi-service tutorial though. I haven't been able to test if it could be replaced by result.toNumber() in idi-service