### PR TITLE
Update chain-deploying.md

### DIFF
--- a/tutorials/advanced/chain-deploying.md
+++ b/tutorials/advanced/chain-deploying.md
@@ -73,7 +73,7 @@ vm_log = false
 
 **N.B.**
 
-For decentralized purists that may not like a single point of failure, a comma delimited list of validators is also an acceptable value for `seeds`. To find the IP addresses of all machines:
+For decentralized purists that may not like a single point of failure, a comma delimited list of peer IP addresses may be entered for `seeds`. To find the IP addresses of all machines:
 
 ```bash
 $ docker-machine ls


### PR DESCRIPTION
peers is apparently a more appropriate word than validators i used when talking about the seeds list. suppose it doesn't really matter... i half wanted to edit this doc to imply that all peers should be entered here as per Jae but didn't want to overstep my bounds in case there is some reasoning i'm not aware of here...