### PR TITLE
Fix a typo: logsrotate

### DIFF
--- a/tutorials/advanced/chain-deploying.md
+++ b/tutorials/advanced/chain-deploying.md
@@ -139,7 +139,7 @@ Now let's get those services turned on.
 ```bash
 for i in `seq 0 6`
 do
-  eris services start watchtower logrotate logspout --machine "my-advchain-val-00$i"
+  eris services start watchtower logsrotate logspout --machine "my-advchain-val-00$i"
 done
 ```
 


### PR DESCRIPTION
The config file in ~/.eris/services is logsrotate.toml
