### PR TITLE
Replace deprecated `suicide(owner)` for `selfdestruct(owner)`

### DIFF
--- a/tutorials/solidity/solidity-1.md
+++ b/tutorials/solidity/solidity-1.md
@@ -61,17 +61,17 @@ contract HelloSystem {
 
 ## Deploying and removing contracts
 
-The `HelloSystem` contract can be deployed as-is without any problems, but once it's been deployed it will remain on the chain for good. We need a way to remove it. In Solidity, the command for removing (or suiciding) a contract is this: `suicide(addr)`. The argument here is the address to which any remaining funds should be sent. In order to expose this functionality, we need to put it inside a (implicitly public) function. This is what a suicide function could look like in `HelloSystem`:
+The `HelloSystem` contract can be deployed as-is without any problems, but once it's been deployed it will remain on the chain for good. We need a way to remove it. In Solidity, the command for removing (or suiciding) a contract is this: `selfdestruct(addr)`. The argument here is the address to which any remaining funds should be sent. In order to expose this functionality, we need to put it inside a (implicitly public) function. This is what a selfdestruct function could look like in `HelloSystem`:
 
 ```javascript
 contract HelloSystem {
     function remove() {
-        suicide(msg.sender);
+        selfdestruct(msg.sender);
     }
 }
 ```
 
-What this would do is to remove the contract when the `remove` function is called, and it would return any funds it may have to the caller. Needless to say, this is not ideal. Normally when you add a suicide function you want to restrict the access to it. The simplest way of doing it is to store the address of the contract creator when the contract is deployed, and only allow the creator to suicide it. Here is how that could be implemented:
+What this would do is to remove the contract when the `remove` function is called, and it would return any funds it may have to the caller. Needless to say, this is not ideal. Normally when you add a selfdestruct function you want to restrict the access to it. The simplest way of doing it is to store the address of the contract creator when the contract is deployed, and only allow the creator to call selfdestruct on it. Here is how that could be implemented:
 
 ```javascript
 contract HelloSystem {
@@ -85,7 +85,7 @@ contract HelloSystem {
 
     function remove() {
         if (msg.sender == owner){
-            suicide(owner);
+            selfdestruct(owner);
         }
     }
 
@@ -108,7 +108,7 @@ contract HelloSystem {
 
     function remove() {
         if (msg.sender == owner){
-            suicide(owner);
+            selfdestruct(owner);
         }
     }
 }
@@ -152,7 +152,7 @@ We're now going to make a simple bank account contract that lets people deposit 
 ```javascript
 contract Bank {
 
-    // We want an owner that is allowed to suicide.
+    // We want an owner that is allowed to selfdestruct.
     address owner;
 
     mapping (address => uint) balances;
@@ -178,7 +178,7 @@ contract Bank {
 
     function remove() {
         if (msg.sender == owner){
-            suicide(owner);
+            selfdestruct(owner);
         }
     }
 
@@ -224,7 +224,7 @@ contract Bank {
 
     function remove() {
         if (msg.sender == owner){
-            suicide(owner);
+            selfdestruct(owner);
         }
     }
 }
@@ -413,7 +413,7 @@ contract Bank {
 
     function remove() {
         if (msg.sender == owner){
-            suicide(owner);
+            selfdestruct(owner);
         }
     }
 
@@ -460,7 +460,7 @@ contract FundManager {
     // *************************************************************************
 
     // We're responsible for this now that we're the owner of the banks.
-    function suicideBank(address addr) {
+    function selfdestructBank(address addr) {
         if (msg.sender != owner){
             return;
         }
@@ -591,7 +591,7 @@ contract Doug {
 
     // This is where we keep all the contracts.
     mapping (bytes32 => address) contracts;
-    
+
     modifier onlyOwner { //a modifier to reduce code replication
         if (msg.sender == owner) // this ensures that only the owner can access the function
             _
@@ -614,7 +614,7 @@ contract Doug {
     }
 
     function remove() onlyOwner {
-        suicide(owner);
+        selfdestruct(owner);
     }
 
 }
@@ -698,7 +698,7 @@ contract DougEnabled {
     // Makes it so that Doug is the only contract that may kill it.
     function remove(){
         if(msg.sender == DOUG){
-            suicide(DOUG);
+            selfdestruct(DOUG);
         }
     }
 
@@ -732,7 +732,7 @@ contract Doug {
         return true;
     }
 
-    // Remove a contract from Doug. We could also suicide if we want to.
+    // Remove a contract from Doug. We could also selfdestruct if we want to.
     function removeContract(bytes32 name) onlyOwner returns (bool result) {
         if (contracts[name] == 0x0){
             return false;
@@ -757,7 +757,7 @@ contract Doug {
 
         // Finally, remove doug. Doug will now have all the funds of the other contracts,
         // and when suiciding it will all go to the owner.
-        suicide(owner);
+        selfdestruct(owner);
     }
 
 }

--- a/tutorials/solidity/solidity-2.md
+++ b/tutorials/solidity/solidity-2.md
@@ -128,7 +128,7 @@ contract Doug {
         return true;
     }
 
-    // Remove a contract from Doug. We could also suicide if we want to.
+    // Remove a contract from Doug. We could also selfdestruct if we want to.
     function removeContract(bytes32 name) returns (bool result) {
        address cName = contracts[name];
         if (cName == 0x0){
@@ -145,7 +145,7 @@ contract Doug {
 
     function remove(){
         if(msg.sender == owner){
-            suicide(owner);
+            selfdestruct(owner);
         }
     }
 
@@ -204,7 +204,7 @@ contract DougEnabled {
     // Makes it so that Doug is the only contract that may kill it.
     function remove(){
         if(msg.sender == DOUG){
-            suicide(DOUG);
+            selfdestruct(DOUG);
         }
     }
 
@@ -856,7 +856,7 @@ contract DougEnabled {
     // Makes it so that Doug is the only contract that may kill it.
     function remove(){
         if(msg.sender == DOUG){
-            suicide(DOUG);
+            selfdestruct(DOUG);
         }
     }
 
@@ -1105,7 +1105,7 @@ contract Doug {
        return true;
   }
 
-    // Remove a contract from Doug. We could also suicide if we want to.
+    // Remove a contract from Doug. We could also selfdestruct if we want to.
     function removeContract(bytes32 name) returns (bool result) {
        address cName = contracts[name];
        if (cName == 0x0){
@@ -1128,7 +1128,7 @@ contract Doug {
 
     function remove(){
         if(msg.sender == owner){
-            suicide(owner);
+            selfdestruct(owner);
         }
     }
 
@@ -1416,7 +1416,7 @@ contract DougDb {
        return true;
     }
 
-    // Remove a contract from Doug (we could also suicide the contract if we want to).
+    // Remove a contract from Doug (we could also selfdestruct the contract if we want to).
     function _removeElement(bytes32 name) internal returns (bool result) {
 
        Element elem = list[name];
@@ -1481,8 +1481,8 @@ contract Doug is DougDb {
 
     /// @notice Add a contract to Doug. This contract should extend DougEnabled, because
     /// Doug will attempt to call 'setDougAddress' on that contract before allowing it
-    /// to register. It will also ensure that the contract cannot be suicided by anyone
-    /// other then Doug. Finally, Doug allows over-writing of previous contracts with
+    /// to register. It will also ensure that the contract cannot be selfdestructed by anyone
+    /// other than Doug. Finally, Doug allows over-writing of previous contracts with
     /// the same name, thus you may replace contracts with new ones.
     /// @param name The bytes32 name of the contract.
     /// @param addr The address to the actual contract.
@@ -1532,12 +1532,12 @@ contract Doug is DougDb {
       return list[name].contractAddress;
     }
 
-    /// @notice Remove (suicide) Doug.
+    /// @notice Remove (selfdestruct) Doug.
     function remove(){
         if(msg.sender == owner){
             // Finally, remove doug. Doug will now have all the funds of the other contracts,
             // and when suiciding it will all go to the owner.
-            suicide(owner);
+            selfdestruct(owner);
         }
     }
 

--- a/tutorials/solidity/solidity-5.md
+++ b/tutorials/solidity/solidity-5.md
@@ -52,13 +52,13 @@ contract mortal is owned {
 
     function kill() {
         if (isOwner()){
-            suicide(owner);
+            selfdestruct(owner);
         }
     }
 }
 ```
 
-Through the rules of inheritance (which is very similar to how it works in C++), `mortal` now has all the fields and function of `owned`, and when it is instantiated it will automatically call the constructor of `owned` which will set the `owner` field. It can also call `isOwner` to do the owner check. Also, if `mortal` is extended by another contract, that contract will have a `kill()` function that suicides the contract and can only be called by the contract creator (which is what the `mortal` contract is for).
+Through the rules of inheritance (which is very similar to how it works in C++), `mortal` now has all the fields and function of `owned`, and when it is instantiated it will automatically call the constructor of `owned` which will set the `owner` field. It can also call `isOwner` to do the owner check. Also, if `mortal` is extended by another contract, that contract will have a `kill()` function that selfdestructs the contract and can only be called by the contract creator (which is what the `mortal` contract is for).
 
 Finally, a very simple [unit-testing contract](/tutorials/solidity/solidity-4/) could be written for `owned` to ensure that it does indeed work:
 
@@ -173,7 +173,7 @@ contract Mortal is Auth {
 
     function kill() {
         if (auth.isAdmin()){
-            suicide(msg.sender);
+            selfdestruct(msg.sender);
         }
     }
 }


### PR DESCRIPTION
The official Solidity docs no longer make any reference to `suicide(owner)`, which could lead to confusion amongst new adopters of Eris and Solidity in general.

This commit updates all references to `suicide(owner)` in the tutorials in order to reflect the latest [Solidity documentation](http://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=selfdestruct#contract-related).